### PR TITLE
05_field_of_view

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -22,4 +22,8 @@ pub struct Player {}
 pub struct Viewshed {
     pub visible_tiles: Vec<rltk::Point>,
     pub range: i32,
+    // dirtyふらぐ
+    // trueのときだけviewshedを再計算する.
+    // 再計算したらfalseにする
+    pub dirty: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@ fn main() -> rltk::BError {
         .with(Viewshed {
             visible_tiles: Vec::new(),
             range: 8,
+            dirty: true,
         })
         .build();
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -15,6 +15,7 @@ pub struct Map {
     pub width: i32,
     pub height: i32,
     pub revealed_tiles: Vec<bool>,
+    pub visible_tiles: Vec<bool>,
 }
 
 impl Map {
@@ -59,6 +60,7 @@ impl Map {
             width: 80,
             height: 50,
             revealed_tiles: vec![false; 80 * 50],
+            visible_tiles: vec![false; 80 * 50],
         };
 
         // ↓で作ったお部屋たちを登録してく
@@ -129,30 +131,27 @@ pub fn draw_map(ecs: &World, ctx: &mut Rltk) {
     let mut y = 0;
     let mut x = 0;
 
-    // enumerateで(index, value)のタプルを生成する
+    // enumerate()で(index, value)のタプルを生成する
     for (idx, tile) in map.tiles.iter().enumerate() {
         // タイルの種類に応じてタイルを描く
         if map.revealed_tiles[idx] {
+            let glyph;
+            let mut fg;
             match tile {
                 TileType::Floor => {
-                    ctx.set(
-                        x,
-                        y,
-                        RGB::from_f32(0.5, 0.5, 0.5),
-                        RGB::from_f32(0., 0., 0.),
-                        rltk::to_cp437('.'),
-                    );
+                    glyph = rltk::to_cp437('.');
+                    fg = RGB::from_f32(0.0, 0.5, 0.5);
                 }
                 TileType::Wall => {
-                    ctx.set(
-                        x,
-                        y,
-                        RGB::from_f32(0.0, 0.7, 0.2),
-                        RGB::from_f32(0., 0., 0.),
-                        rltk::to_cp437('#'),
-                    );
+                    glyph = rltk::to_cp437('#');
+                    fg = RGB::from_f32(0., 1.0, 0.);
                 }
             }
+
+            if !map.visible_tiles[idx] {
+                fg = fg.to_greyscale()
+            }
+            ctx.set(x, y, fg, RGB::from_f32(0., 0., 0.), glyph);
         }
 
         // 座標を動かす

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,3 +1,5 @@
+use crate::Viewshed;
+
 use super::{Map, Player, Position, State, TileType};
 use rltk::{Rltk, VirtualKeyCode};
 use specs::prelude::*;
@@ -6,13 +8,17 @@ use std::cmp::{max, min};
 pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     let mut positions = ecs.write_storage::<Position>();
     let mut players = ecs.write_storage::<Player>();
+    let mut viewsheds = ecs.write_storage::<Viewshed>();
     let map = ecs.fetch::<Map>();
 
-    for (_player, pos) in (&mut players, &mut positions).join() {
+    for (_player, pos, viewshed) in (&mut players, &mut positions, &mut viewsheds).join() {
         let destination_idx = map.xy_idx(pos.x + delta_x, pos.y + delta_y);
         if map.tiles[destination_idx] != TileType::Wall {
             pos.x = min(79, max(0, pos.x + delta_x));
             pos.y = min(49, max(0, pos.y + delta_y));
+
+            // @くんが移動したら視界が変わるからdirtyふらぐもtrueにする
+            viewshed.dirty = true;
         }
     }
 }

--- a/src/visibility_system.rs
+++ b/src/visibility_system.rs
@@ -17,19 +17,28 @@ impl<'a> System<'a> for VisibilitySystem {
         let (mut map, entities, mut viewshed, pos, player) = data;
 
         for (ent, viewshed, pos) in (&entities, &mut viewshed, &pos).join() {
-            viewshed.visible_tiles.clear();
-            viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-            viewshed
-                .visible_tiles
-                // 条件を満たす要素だけ残す.JSのfilterのようなものだけど破壊的.元の配列を変更する.
-                .retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height);
+            if viewshed.dirty {
+                viewshed.dirty = false;
+                viewshed.visible_tiles.clear();
+                viewshed.visible_tiles =
+                    field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
+                viewshed
+                    .visible_tiles
+                    // 条件を満たす要素だけ残す.JSのfilterのようなものだけど破壊的.元の配列を変更する.
+                    .retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height);
 
-            // playerなら視界内のタイルを明らかにする
-            let p: Option<&Player> = player.get(ent);
-            if let Some(p) = p {
-                for vis in viewshed.visible_tiles.iter() {
-                    let idx = map.xy_idx(vis.x, vis.y);
-                    map.revealed_tiles[idx] = true;
+                // playerなら視界内のタイルを明らかにする
+                let p: Option<&Player> = player.get(ent);
+                if let Some(p) = p {
+                    for t in map.visible_tiles.iter_mut() {
+                        *t = false
+                    }
+
+                    for vis in viewshed.visible_tiles.iter() {
+                        let idx = map.xy_idx(vis.x, vis.y);
+                        map.revealed_tiles[idx] = true;
+                        map.visible_tiles[idx] = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### `@`くん(プレイヤー)の視界を導入する(viewshed)

- `@`くんがまだ見てない箇所はまっくら
- `@`くんの視界内に入ったタイルは明らかになる
- いっかい見たタイルは明らかになったまま
- `@`くんの現在の視界は緑色で表示される.視界外は灰色

### パフォーマンス

- viewshedに`dirty`フラグをもたせる.
  - trueのときに限りviewshedの再計算をする

https://user-images.githubusercontent.com/23167368/213874602-2bc58145-eaab-4f09-a49f-d12adcb5f590.mov

